### PR TITLE
Disable CGO to fix Docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,8 @@ brews:
       name: homebrew-tap
       owner: mcornick
 builds:
-  - flags:
+  - env: [CGO_ENABLED=0]
+    flags:
       - -trimpath
     goos:
       - darwin


### PR DESCRIPTION
Apparently CGO is on by default, and this results in non-static binaries (at least on amd64) which don't work on the scratch Docker image.